### PR TITLE
Correct `TST_N` and `TSTIO_N` opcode length calculation

### DIFF
--- a/Z80/goodies/z80_opcode_length.cpp
+++ b/Z80/goodies/z80_opcode_length.cpp
@@ -145,7 +145,7 @@ uint z180_opcode_length (uint8* ip)
 		case 0:										// IN0_r_xN and OUT0_xN_r
 			return 2 + ((op2&7)<=1 && op2!=0x31);	// not shure for 0x31: ill. OUT0_xN_0 ?
 		case 1:
-			if ((op2|0x10)==0x76) return 7;			// TST_N and TSTIO_N
+			if ((op2|0x10)==0x74) return 7;			// TST_N and TSTIO_N
 			else break;
 		}
 	}

--- a/Z80/goodies/z80_opcode_length.cpp
+++ b/Z80/goodies/z80_opcode_length.cpp
@@ -145,7 +145,7 @@ uint z180_opcode_length (uint8* ip)
 		case 0:										// IN0_r_xN and OUT0_xN_r
 			return 2 + ((op2&7)<=1 && op2!=0x31);	// not shure for 0x31: ill. OUT0_xN_0 ?
 		case 1:
-			if ((op2|0x10)==0x74) return 7;			// TST_N and TSTIO_N
+			if ((op2|0x10)==0x74) return 3;			// TST_N and TSTIO_N
 			else break;
 		}
 	}


### PR DESCRIPTION
`TST m` is `0xED 0x64 m`, and `TSTIO m` is `0xED 0x74 m`. This PR fixes the test from `0x76` to `0x74` and the length from 7 to 3. The first fix is necessary to prevent zasm from crashing on `TST m` when writing opcode cycle counts to the listing file. The second doesn't seem to be necessary to prevent the crash.